### PR TITLE
Fe 19: Create quiz session

### DIFF
--- a/web/src/components/quiz/optionComponent.tsx
+++ b/web/src/components/quiz/optionComponent.tsx
@@ -1,47 +1,39 @@
 import { Button } from "@chakra-ui/react";
 import { FC, useMemo } from "react";
 import { useColors } from "../../hooks/useColors";
-import { Answer } from "../../model/answer";
+import { QuestionOption } from "../../model/questionOption";
 
 interface optionProps {
-  indexString?: string;
-  answer: Answer;
-  userAnswer: Answer | null;
-  isAnswered?: boolean;
-  onClick: (answer: Answer) => void;
+  option: QuestionOption;
+  answer: QuestionOption | undefined;
+  onClick: (answer: QuestionOption) => void;
 }
 
-const Option: FC<optionProps> = ({
-  indexString,
-  userAnswer,
-  answer,
-  isAnswered,
-  onClick,
-}) => {
+const Option: FC<optionProps> = ({ answer, option, onClick }) => {
   const { optionBg, optionBgHover, optionCorrect, optionIncorrect } =
     useColors();
 
   const bgColor = useMemo(
     () =>
-      !userAnswer
+      !answer
         ? optionBg
-        : answer.isCorrect
+        : option.isCorrect
         ? optionCorrect
-        : userAnswer === answer
+        : answer === option
         ? optionIncorrect
         : optionBg,
-    [userAnswer, answer, optionBg, optionCorrect, optionIncorrect]
+    [answer, option, optionBg, optionCorrect, optionIncorrect]
   );
 
   return (
     <Button
       bg={bgColor}
-      _hover={!userAnswer ? { backgroundColor: optionBgHover } : {}}
+      _hover={!answer ? { backgroundColor: optionBgHover } : {}}
       fontWeight="normal"
       justifyContent="start"
-      onClick={(e) => onClick(answer)}
+      onClick={(e) => onClick(option)}
     >
-      {answer.text}
+      {option.text}
     </Button>
   );
 };

--- a/web/src/components/quiz/optionComponent.tsx
+++ b/web/src/components/quiz/optionComponent.tsx
@@ -1,41 +1,45 @@
 import { Button } from "@chakra-ui/react";
-import {FC, useCallback, useMemo, useState} from "react";
+import { FC, useMemo } from "react";
 import { useColors } from "../../hooks/useColors";
-import Answer from "../../model/answer";
+import { Answer } from "../../model/answer";
 
 interface optionProps {
   indexString?: string;
   answer: Answer;
-  isAnswered: boolean;
+  userAnswer: Answer | null;
+  isAnswered?: boolean;
   onClick: (answer: Answer) => void;
 }
 
 const Option: FC<optionProps> = ({
   indexString,
+  userAnswer,
   answer,
   isAnswered,
   onClick,
 }) => {
-  const { optionBg, optionBgHover, optionCorrect, optionIncorrect } = useColors();
-  const [selected, setSelected] = useState(false);
+  const { optionBg, optionBgHover, optionCorrect, optionIncorrect } =
+    useColors();
 
-  const click = useCallback(() => {
-    !isAnswered && onClick(answer);
-    !isAnswered && setSelected(true);
-  }, [setSelected])
-
-  const color = useMemo(() =>
-    !isAnswered ? optionBg : answer.isCorrect ? optionCorrect : selected ? optionIncorrect : optionBg,
-      [isAnswered, selected]
-)
+  const bgColor = useMemo(
+    () =>
+      !userAnswer
+        ? optionBg
+        : answer.isCorrect
+        ? optionCorrect
+        : userAnswer === answer
+        ? optionIncorrect
+        : optionBg,
+    [userAnswer, answer, optionBg, optionCorrect, optionIncorrect]
+  );
 
   return (
     <Button
-      bg={ color }
-      _hover={!isAnswered ? { backgroundColor: optionBgHover } : {}}
+      bg={bgColor}
+      _hover={!userAnswer ? { backgroundColor: optionBgHover } : {}}
       fontWeight="normal"
       justifyContent="start"
-      onClick={(e) => click()}
+      onClick={(e) => onClick(answer)}
     >
       {answer.text}
     </Button>

--- a/web/src/components/quiz/questionComponent.tsx
+++ b/web/src/components/quiz/questionComponent.tsx
@@ -1,6 +1,7 @@
-import { Stack, Heading } from "@chakra-ui/react";
-import { FC, useState } from "react";
-import Question from "../../model/question";
+import { Heading, Stack } from "@chakra-ui/react";
+import { FC, useEffect, useState } from "react";
+import { Answer } from "../../model/answer";
+import { Question } from "../../model/question";
 import Option from "./optionComponent";
 
 interface questionProp {
@@ -8,7 +9,8 @@ interface questionProp {
 }
 
 const QuestionComponent: FC<questionProp> = ({ question }) => {
-  const [isAnswered, setIsAnswered] = useState(false);
+  //const [isAnswered, setIsAnswered] = useState(false);
+  const [userAnswer, setUserAnswer] = useState<Answer | null>(null);
 
   return (
     <div>
@@ -17,8 +19,8 @@ const QuestionComponent: FC<questionProp> = ({ question }) => {
         {question.answers.map((answer, i) => (
           <Option
             answer={answer}
-            isAnswered={isAnswered}
-            onClick={(answer) => setIsAnswered(true)}
+            userAnswer={userAnswer}
+            onClick={(answer) => !userAnswer && setUserAnswer(answer)}
             key={i}
           />
         ))}

--- a/web/src/components/quiz/questionComponent.tsx
+++ b/web/src/components/quiz/questionComponent.tsx
@@ -1,32 +1,40 @@
 import { Heading, Stack } from "@chakra-ui/react";
-import { FC, useEffect, useState } from "react";
-import { Answer } from "../../model/answer";
+import { observer } from "mobx-react-lite";
+import { FC, useCallback } from "react";
 import { Question } from "../../model/question";
+import { QuestionOption } from "../../model/questionOption";
+import { QuizStore } from "../../stores/quizStore";
 import Option from "./optionComponent";
 
 interface questionProp {
   question: Question;
 }
 
-const QuestionComponent: FC<questionProp> = ({ question }) => {
-  //const [isAnswered, setIsAnswered] = useState(false);
-  const [userAnswer, setUserAnswer] = useState<Answer | null>(null);
+const QuestionComponent: FC<questionProp> = observer(({ question }) => {
+  const answer = QuizStore.quizSession?.answers.get(question);
+
+  const handleAnswer = useCallback(
+    (option: QuestionOption) => {
+      !answer && QuizStore.answerQuestion(question, option);
+    },
+    [question, answer]
+  );
 
   return (
     <div>
       <Heading size="md">{question.description}</Heading>
       <Stack spacing={2}>
-        {question.answers.map((answer, i) => (
+        {question.options.map((option, i) => (
           <Option
+            option={option}
             answer={answer}
-            userAnswer={userAnswer}
-            onClick={(answer) => !userAnswer && setUserAnswer(answer)}
+            onClick={handleAnswer}
             key={i}
           />
         ))}
       </Stack>
     </div>
   );
-};
+});
 
 export default QuestionComponent;

--- a/web/src/components/quiz/quizComponent.tsx
+++ b/web/src/components/quiz/quizComponent.tsx
@@ -1,23 +1,18 @@
 import { Button } from "@chakra-ui/button";
 import { Heading, HStack, Stack, Text } from "@chakra-ui/layout";
 import { observer } from "mobx-react-lite";
-import { FC, useCallback, useMemo, useState } from "react";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { QuizStore } from "../../stores/quizStore";
 import QuestionComponent from "./questionComponent";
-import { QuizSession } from "../../model/quizSession";
-import { Question } from "../../model/question";
-import { Answer } from "../../model/answer";
 
 const QuizComponent: FC = observer(() => {
   const quiz = QuizStore.getQuiz(1); //TODO: quiz id should be read from route
 
-  if (!quiz) return <></>;
+  if (!quiz) return <></>; //TODO: Render something that indicates the quiz cannot be found
 
-  const [quizSession, setQuizSession] = useState<QuizSession>({
-    quiz: quiz,
-    userId: 1,
-    answers: new Map<Question, Answer>(),
-  });
+  useEffect(() => {
+    QuizStore.newQuizSession(quiz);
+  }, [quiz]);
 
   const [question, setQuestion] = useState(quiz?.questions[0]);
 
@@ -33,8 +28,6 @@ const QuizComponent: FC = observer(() => {
     [quiz, setQuestion]
   );
 
-  //useEffect(() => console.log(question), [question]);
-
   return (
     <>
       {quiz && question && (
@@ -44,6 +37,7 @@ const QuizComponent: FC = observer(() => {
           <Text>{`Question ${currentQuestionIndex + 1}/${
             quiz.questions.length
           }`}</Text>
+          <Text>{QuizStore.correctAnswers} correct</Text>
           <HStack>
             <Button onClick={() => changeQuestion(currentQuestionIndex - 1)}>
               Previous

--- a/web/src/components/quiz/quizComponent.tsx
+++ b/web/src/components/quiz/quizComponent.tsx
@@ -1,38 +1,61 @@
-import {FC, useCallback, useMemo, useState} from "react";
-import { observer } from "mobx-react-lite";
-import QuestionComponent from "./questionComponent";
-import { QuizStore } from "../../stores/quizStore";
 import { Button } from "@chakra-ui/button";
 import { Heading, HStack, Stack, Text } from "@chakra-ui/layout";
+import { observer } from "mobx-react-lite";
+import { FC, useCallback, useMemo, useState } from "react";
+import { QuizStore } from "../../stores/quizStore";
+import QuestionComponent from "./questionComponent";
+import { QuizSession } from "../../model/quizSession";
+import { Question } from "../../model/question";
+import { Answer } from "../../model/answer";
 
 const QuizComponent: FC = observer(() => {
+  const quiz = QuizStore.getQuiz(1); //TODO: quiz id should be read from route
 
-    const quiz = QuizStore.getQuiz(1); //TODO: quiz id should be read from route
-    const [question, setQuestion] = useState(quiz?.questions[0])
-    
-    const currentQuestionIndex = useMemo(() => quiz?.questions.findIndex(q => q === question) ?? 0, [quiz, question]);
+  if (!quiz) return <></>;
 
-    const changeQuestion = useCallback((index: number) => {
-        quiz?.questions[index] && setQuestion(quiz.questions[index]);
-    }, [quiz, setQuestion]);
+  const [quizSession, setQuizSession] = useState<QuizSession>({
+    quiz: quiz,
+    userId: 1,
+    answers: new Map<Question, Answer>(),
+  });
 
-    return (
-        <>
-        {
-            quiz && question && (
-            <Stack>
-                <Heading size="md">{quiz.title}</Heading>
-                <QuestionComponent question={question}/>
-                <Text>{`Question ${currentQuestionIndex + 1}/${quiz.questions.length}`}</Text>
-                <HStack>
-                    <Button onClick={() => changeQuestion(currentQuestionIndex - 1)}>Previous</Button>
-                    <Button onClick={() => changeQuestion(currentQuestionIndex + 1)}>Next</Button>
-                </HStack>
-            </Stack>
-            )
-        }
-        </>
-    );
+  const [question, setQuestion] = useState(quiz?.questions[0]);
+
+  const currentQuestionIndex = useMemo(
+    () => quiz?.questions.findIndex((q) => q === question) ?? 0,
+    [quiz, question]
+  );
+
+  const changeQuestion = useCallback(
+    (index: number) => {
+      quiz?.questions[index] && setQuestion(quiz.questions[index]);
+    },
+    [quiz, setQuestion]
+  );
+
+  //useEffect(() => console.log(question), [question]);
+
+  return (
+    <>
+      {quiz && question && (
+        <Stack>
+          <Heading size="md">{quiz.title}</Heading>
+          <QuestionComponent question={question} />
+          <Text>{`Question ${currentQuestionIndex + 1}/${
+            quiz.questions.length
+          }`}</Text>
+          <HStack>
+            <Button onClick={() => changeQuestion(currentQuestionIndex - 1)}>
+              Previous
+            </Button>
+            <Button onClick={() => changeQuestion(currentQuestionIndex + 1)}>
+              Next
+            </Button>
+          </HStack>
+        </Stack>
+      )}
+    </>
+  );
 });
 
 export default QuizComponent;

--- a/web/src/model/answer.ts
+++ b/web/src/model/answer.ts
@@ -1,4 +1,4 @@
-export default interface Answer {
-    text:       string,
-    isCorrect:  boolean
-}
+export type Answer = {
+  text: string;
+  isCorrect: boolean;
+};

--- a/web/src/model/question.ts
+++ b/web/src/model/question.ts
@@ -1,6 +1,6 @@
-import Answer from "./answer";
+import { Answer } from "./answer";
 
-export default interface Question {
-    description:    string,
-    answers:        Answer[]
-}
+export type Question = {
+  description: string;
+  answers: Answer[];
+};

--- a/web/src/model/question.ts
+++ b/web/src/model/question.ts
@@ -1,6 +1,6 @@
-import { Answer } from "./answer";
+import { QuestionOption } from "./questionOption";
 
 export type Question = {
   description: string;
-  answers: Answer[];
+  options: QuestionOption[];
 };

--- a/web/src/model/questionOption.ts
+++ b/web/src/model/questionOption.ts
@@ -1,4 +1,4 @@
-export type Answer = {
+export type QuestionOption = {
   text: string;
   isCorrect: boolean;
 };

--- a/web/src/model/quiz.ts
+++ b/web/src/model/quiz.ts
@@ -1,10 +1,10 @@
-import Question from "./question";
+import { Question } from "./question";
 
-export default interface Quiz {
-    id:             number,
-    title?:         string,
-    category?:      string,
-    description?:   string,
-    createdBy:      number,  // user ID
-    questions:      Question[]
-}
+export type Quiz = {
+  id: number;
+  title?: string;
+  category?: string;
+  description?: string;
+  createdBy: number; // user ID
+  questions: Question[];
+};

--- a/web/src/model/quizSession.ts
+++ b/web/src/model/quizSession.ts
@@ -1,9 +1,9 @@
-import { Answer } from "./answer";
+import { QuestionOption } from "./questionOption";
 import { Question } from "./question";
 import { Quiz } from "./quiz";
 
 export type QuizSession = {
   userId: number;
   quiz: Quiz;
-  answers: Map<Question, Answer>;
+  answers: Map<Question, QuestionOption>;
 };

--- a/web/src/model/quizSession.ts
+++ b/web/src/model/quizSession.ts
@@ -1,0 +1,9 @@
+import { Answer } from "./answer";
+import { Question } from "./question";
+import { Quiz } from "./quiz";
+
+export type QuizSession = {
+  userId: number;
+  quiz: Quiz;
+  answers: Map<Question, Answer>;
+};

--- a/web/src/stores/quizStore.ts
+++ b/web/src/stores/quizStore.ts
@@ -1,14 +1,22 @@
-import { makeObservable, observable, action } from "mobx";
+import { makeObservable, observable, action, computed } from "mobx";
+import { QuestionOption } from "../model/questionOption";
+import { Question } from "../model/question";
 import { Quiz } from "../model/quiz";
+import { QuizSession } from "../model/quizSession";
 
 export class QuizStoreImpl {
   quizes: Quiz[] = [];
+  quizSession: QuizSession | undefined;
 
   constructor() {
     makeObservable(this, {
       quizes: observable,
+      quizSession: observable,
       addQuiz: action,
       getQuiz: action,
+      newQuizSession: action,
+      answerQuestion: action,
+      correctAnswers: computed,
     });
   }
 
@@ -18,6 +26,26 @@ export class QuizStoreImpl {
 
   getQuiz(id: number) {
     return this.quizes.find((quiz) => quiz.id === id);
+  }
+
+  newQuizSession(quiz: Quiz) {
+    this.quizSession = {
+      userId: 1,
+      quiz: quiz,
+      answers: new Map<Question, QuestionOption>(),
+    };
+  }
+
+  answerQuestion(question: Question, answer: QuestionOption) {
+    this.quizSession?.answers.set(question, answer);
+  }
+
+  get correctAnswers(): number {
+    if (!this.quizSession) return 0;
+    return Array.from(this.quizSession.answers.values()).reduce(
+      (acc, answer) => (answer.isCorrect ? acc + 1 : acc),
+      0
+    );
   }
 }
 
@@ -33,7 +61,7 @@ const testQuiz1: Quiz = {
   questions: [
     {
       description: "Hvilket problem forsøger DevOps at løse?",
-      answers: [
+      options: [
         {
           text: "Lange deployment cycles",
           isCorrect: false,
@@ -54,7 +82,7 @@ const testQuiz1: Quiz = {
     },
     {
       description: "nyt spørgsmål",
-      answers: [
+      options: [
         {
           text: "test",
           isCorrect: false,

--- a/web/src/stores/quizStore.ts
+++ b/web/src/stores/quizStore.ts
@@ -1,73 +1,72 @@
 import { makeObservable, observable, action } from "mobx";
-import Quiz from "../model/quiz";
+import { Quiz } from "../model/quiz";
 
 export class QuizStoreImpl {
+  quizes: Quiz[] = [];
 
-    quizes: Quiz[] = [];
+  constructor() {
+    makeObservable(this, {
+      quizes: observable,
+      addQuiz: action,
+      getQuiz: action,
+    });
+  }
 
-    constructor() {
-        makeObservable(this, {
-            quizes: observable,
-            addQuiz: action,
-            getQuiz: action,
-        });
-    }
+  addQuiz(quiz: Quiz) {
+    this.quizes.push(quiz);
+  }
 
-    addQuiz(quiz: Quiz) {
-        this.quizes.push(quiz);
-    }
-
-    getQuiz(id: number) {
-        return this.quizes.find(quiz => quiz.id === id)
-    }
+  getQuiz(id: number) {
+    return this.quizes.find((quiz) => quiz.id === id);
+  }
 }
 
 export const QuizStore = new QuizStoreImpl();
 
- //Create a test quiz. Only temporary for mock data.
- const testQuiz1: Quiz = {
-    id: 1,
-    title: "DevOps quizzen",
-    category: "DevOps",
-    description: "En quiz om DevOps",
-    createdBy: 1,
-    questions: [
-      {
-        description: "Hvilket problem forsøger DevOps at løse?",
-        answers: [
-          {
-            text: "Lange deployment cycles",
-            isCorrect: false
-          },
-          {
-            text: "Skrøbelig infrastruktur og applikationskode",
-            isCorrect: false
-          },
-          {
-            text: "Ineffektive eller uddaterede applikationer",
-            isCorrect: false
-          },
-          {
-            text: "Alle ovenstående",
-            isCorrect: true
-          }
-        ]
-      },
-      {
-          description: "nyt spørgsmål",
-          answers: [
-              {
-                  text: "test",
-                  isCorrect: false
-              },
-              {
-                  text: "test2",
-                  isCorrect: true
-              }
-          ]
-      }
-    ]
-  }
+//Create a test quiz. Only temporary for mock data.
+const testQuiz1: Quiz = {
+  id: 1,
+  title: "DevOps quizzen",
+  category: "DevOps",
+  description: "En quiz om DevOps",
+  createdBy: 1,
+  questions: [
+    {
+      description: "Hvilket problem forsøger DevOps at løse?",
+      answers: [
+        {
+          text: "Lange deployment cycles",
+          isCorrect: false,
+        },
+        {
+          text: "Skrøbelig infrastruktur og applikationskode",
+          isCorrect: false,
+        },
+        {
+          text: "Ineffektive eller uddaterede applikationer",
+          isCorrect: false,
+        },
+        {
+          text: "Alle ovenstående",
+          isCorrect: true,
+        },
+      ],
+    },
+    {
+      description: "nyt spørgsmål",
+      answers: [
+        {
+          text: "test",
+          isCorrect: false,
+        },
+        {
+          text: "test2",
+          isCorrect: true,
+        },
+      ],
+    },
+  ],
+};
 
-  //Add test quiz to store. Only temporary for mock data.
-  QuizStore.addQuiz(testQuiz1);
+//Add test quiz to store. Only temporary for mock data.
+QuizStore.addQuiz(testQuiz1);


### PR DESCRIPTION
closes #19 

I mit arbejde på at få quizzen til at fungere, endte jeg med at tilføje en en ny type, QuizSession, som også bruges i storen. Vil gerne høre jeres tanker om det: Min tanke er, at en Quiz kun definerer selve quizzen og dens spørgsmål, og at en  QuizSession (eller hvad vi nu vil kalde den), definerer selve det at tage en quiz – sådan at den holder styr på progressionen/hvad man har svaret.

Dette løser problemet med at hvert spørgsmål i en quiz havde det samme state, så når et spørgsmål var besvaret troede alle spørgsmål at de var besvaret