### PR TITLE
Be 32: feat(quiz) - Setup with the quiz.api to generate quizes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,13 @@
             <artifactId>lombok</artifactId>
             <version>1.18.10</version>
         </dependency>
+
+        <!-- Jersey JAX-RS client -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.27</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,28 @@
             <artifactId>jersey-client</artifactId>
             <version>2.27</version>
         </dependency>
+
+        <!--junit-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.5.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.5.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Mockito  -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.21.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -217,6 +239,18 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- for unit tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+                <configuration>
+                    <argLine>
+                        --illegal-access=permit
+                    </argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/Quiz/QuizApiClient.java
+++ b/src/main/java/Quiz/QuizApiClient.java
@@ -1,4 +1,28 @@
 package Quiz;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 public class QuizApiClient {
+
+    private static final String URL = "https://quizapi.io/api/v1/questions";
+    private static final String API_KEY = "X-Api-Key";
+    private static final String API_KEY_VALUE = "9AnuuVYnBmY5hSQ5AO4PLVTXBse8PYaxC0Rz9W0f";
+
+    private final Client client = ClientBuilder.newClient();
+
+    /**
+     * HTTP GET - Gets a random quiz
+     *
+     * @return Response
+     */
+    public Response getQuiz() {
+        return client
+                .target(URL)
+                .request(MediaType.APPLICATION_JSON)
+                .header(API_KEY, API_KEY_VALUE)
+                .get();
+    }
 }

--- a/src/main/java/Quiz/QuizApiClient.java
+++ b/src/main/java/Quiz/QuizApiClient.java
@@ -1,28 +1,34 @@
 package Quiz;
 
+import lombok.Data;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
+@Data
 public class QuizApiClient {
 
     private static final String URL = "https://quizapi.io/api/v1/questions";
     private static final String API_KEY = "X-Api-Key";
     private static final String API_KEY_VALUE = "9AnuuVYnBmY5hSQ5AO4PLVTXBse8PYaxC0Rz9W0f";
 
-    private final Client client = ClientBuilder.newClient();
+    private Client client = ClientBuilder.newClient();
 
     /**
      * HTTP GET - Gets a random quiz
      *
-     * @return Response
+     * @return String
      */
-    public Response getQuiz() {
+    public String getQuiz() {
         return client
                 .target(URL)
                 .request(MediaType.APPLICATION_JSON)
                 .header(API_KEY, API_KEY_VALUE)
-                .get();
+                .get()
+                .readEntity(String.class);
+
+        // TODO: Do entity mapping
+        // TODO: Error handling
     }
 }

--- a/src/main/java/Quiz/QuizApiClient.java
+++ b/src/main/java/Quiz/QuizApiClient.java
@@ -2,6 +2,7 @@ package Quiz;
 
 import lombok.Data;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
@@ -20,7 +21,7 @@ public class QuizApiClient {
      *
      * @return String
      */
-    public String getQuiz() {
+    public String getQuiz() throws ClientErrorException {
         return client
                 .target(URL)
                 .request(MediaType.APPLICATION_JSON)
@@ -29,6 +30,5 @@ public class QuizApiClient {
                 .readEntity(String.class);
 
         // TODO: Do entity mapping
-        // TODO: Error handling
     }
 }

--- a/src/main/java/Quiz/QuizApiClient.java
+++ b/src/main/java/Quiz/QuizApiClient.java
@@ -1,0 +1,4 @@
+package Quiz;
+
+public class QuizApiClient {
+}

--- a/src/test/java/Quiz/QuizApiClientTest.java
+++ b/src/test/java/Quiz/QuizApiClientTest.java
@@ -3,6 +3,7 @@ package Quiz;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.*;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 class QuizApiClientTest {
@@ -40,19 +42,29 @@ class QuizApiClientTest {
         when(invocationBuilderMock.header(anyString(), anyString())).thenReturn(invocationBuilderMock);
         when(invocationBuilderMock.get()).thenReturn(responseMock);
 
-        // TODO: find better solution than casting...
-        when(responseMock.readEntity((Class<Object>) any())).thenReturn("Hello there");
-
         quizApiClient = new QuizApiClient();
         quizApiClient.setClient(clientMock);
     }
 
     @Test
+    public void getQuizParamsTest() {
+        quizApiClient.getQuiz();
+
+        verify(clientMock, times(1)).target("https://quizapi.io/api/v1/questions");
+        verify(webTargetMock, times(1)).request(MediaType.APPLICATION_JSON);
+        verify(invocationBuilderMock,times(1)).header(eq("X-Api-Key"), anyString());
+        verify(invocationBuilderMock, times(1)).get();
+        verify(responseMock, times(1)).readEntity(String.class);
+    }
+
+    @Test
     public void getQuizTest() {
+        // TODO: find better solution than casting...
+        when(responseMock.readEntity((Class<Object>) any())).thenReturn("Hello there");
+
         String string = quizApiClient.getQuiz();
 
         assertEquals("Hello there", string);
-
     }
   
 }

--- a/src/test/java/Quiz/QuizApiClientTest.java
+++ b/src/test/java/Quiz/QuizApiClientTest.java
@@ -1,0 +1,58 @@
+package Quiz;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.mockito.Mockito.*;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+class QuizApiClientTest {
+
+    private QuizApiClient quizApiClient;
+
+    @Mock
+    private Client clientMock;
+
+    @Mock
+    private WebTarget webTargetMock;
+
+    @Mock
+    private Invocation.Builder invocationBuilderMock;
+
+    @Mock
+    private Response responseMock;
+
+
+    @BeforeEach
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+
+        when(clientMock.target(anyString())).thenReturn(webTargetMock);
+        when(webTargetMock.request(anyString())).thenReturn(invocationBuilderMock);
+        when(invocationBuilderMock.header(anyString(), anyString())).thenReturn(invocationBuilderMock);
+        when(invocationBuilderMock.get()).thenReturn(responseMock);
+
+        // TODO: find better solution than casting...
+        when(responseMock.readEntity((Class<Object>) any())).thenReturn("Hello there");
+
+        quizApiClient = new QuizApiClient();
+        quizApiClient.setClient(clientMock);
+    }
+
+    @Test
+    public void getQuizTest() {
+        String string = quizApiClient.getQuiz();
+
+        assertEquals("Hello there", string);
+
+    }
+  
+}


### PR DESCRIPTION
This PR does not complet the issue. I would like some feedback and discussion/input on handling the entity mapping. Should I map to the same entities as in models?

Quizzes received from QuizApi.io are list of questions as JSON-objects with the form. 

{
        "id": 134,
        "question": "Inline elements are normally displayed without starting a new line",
        "description": null,
        "answers": {
            "answer_a": "True",
            "answer_b": "False",
            "answer_c": null,
            "answer_d": null,
            "answer_e": null,
            "answer_f": null
        },
        "multiple_correct_answers": "false",
        "correct_answers": {
            "answer_a_correct": "true",
            "answer_b_correct": "false",
            "answer_c_correct": "false",
            "answer_d_correct": "false",
            "answer_e_correct": "false",
            "answer_f_correct": "false"
        },
        "correct_answer": "answer_a",
        "explanation": null,
        "tip": null,
        "tags": [
            {
                "name": "HTML"
            }
        ],
        "category": "",
        "difficulty": "Easy"
    },