### PR TITLE
Fe 39 quiz flow

### DIFF
--- a/web/src/components/header/navbar.tsx
+++ b/web/src/components/header/navbar.tsx
@@ -9,7 +9,7 @@ const NavBar: FC = ({ children }) => {
             <HStack spacing={5}>
                 {/* TODO: Actual navigation links */}
                 <Link to={"/"} ><Text>Home</Text></Link>
-                <Link to={"/quiz"}><Text>Start Quiz</Text></Link>
+                <Link to={"/quiz/1"}><Text>Start Quiz</Text></Link>
                 {/* <Link>Link</Link> */}
             </HStack>
         </nav>

--- a/web/src/components/quiz/questionComponent.tsx
+++ b/web/src/components/quiz/questionComponent.tsx
@@ -22,7 +22,7 @@ const QuestionComponent: FC<questionProp> = observer(({ question }) => {
 
   return (
     <div>
-      <Heading size="md">{question.description}</Heading>
+      <Heading mb="5px" size="md">{question.description}</Heading>
       <Stack spacing={4}>
         {question.options.map((option, i) => (
           <Option

--- a/web/src/components/quiz/quizCompletion.tsx
+++ b/web/src/components/quiz/quizCompletion.tsx
@@ -1,24 +1,31 @@
-import {Box, HStack, Text, VStack, Button, Stack, Center} from '@chakra-ui/react';
-import {FC} from 'react';
+import {Box, HStack, Heading, Text, VStack, Button, Stack, Center, Progress} from '@chakra-ui/react';
+import { observer } from 'mobx-react-lite';
+import {FC, useCallback, useEffect} from 'react';
 import {Link} from "react-router-dom";
+import { useLocation, useParams } from "react-router";
+import { Quiz } from '../../model/quiz';
+import { QuizStore } from '../../stores/quizStore';
 
-interface completionProp {
+type completionProp = {
     correctAnswers: number,
-    questionAmount: number,
-    quizName?: string
+    quiz: Quiz
 }
 
-const QuizCompletion: FC<completionProp> = ({correctAnswers, questionAmount, quizName}) => {
+const QuizCompletion: FC<completionProp> = observer(({correctAnswers, quiz}) => {
+
     return (
-        <Box>
-            <Text align={"center"}>{quizName}</Text>
-            <Text mt={75} align={"center"}>Tillykke du er færdig</Text>
-            <Text mt={100} align={"center"}>{correctAnswers}/{questionAmount} korrekte svar</Text>
-            <Center mt={150}>
-                <Link to={"/"}><Button>Afslut Quiz</Button></Link>
+        <Box align="center"  borderWidth="1px" borderColor="black" borderRadius="xl" shadow="xl" p="10px">
+            <Heading align={"center"}>{quiz.title}</Heading>
+            <Text mt={75} fontSize="lg" align={"center"}>Congratulations you've finished the quiz</Text>
+            <Text mt={100} fontSize="lg" align={"center"}>You answered {correctAnswers} out of {quiz.questions.length} questions</Text>
+            <Box w="40vw" mt="20px" align="left" >
+                <Progress borderWidth="1px" borderColor="black" borderRadius="lg" size="lg"  hasStripe value={correctAnswers/quiz.questions.length*100} />
+            </Box>
+            <Center  mt={150}>
+                <Link to={"/"}><Button onClick={()=> QuizStore.newQuizSession(quiz)} colorScheme="blue">Close quiz</Button></Link>
             </Center>
         </Box>
     )
-}
+});
 
 export default QuizCompletion;

--- a/web/src/components/quiz/quizComponent.tsx
+++ b/web/src/components/quiz/quizComponent.tsx
@@ -2,40 +2,40 @@ import {Button} from "@chakra-ui/button";
 import {Heading, HStack, Stack, Text} from "@chakra-ui/layout";
 import {observer} from "mobx-react-lite";
 import {FC, useCallback, useEffect, useMemo, useState} from "react";
+import { Quiz } from "../../model/quiz";
 import {QuizStore} from "../../stores/quizStore";
 import QuestionComponent from "./questionComponent";
 import QuizCompletion from "./quizCompletion";
 
-const QuizComponent: FC = observer(() => {
-    const quiz = QuizStore.getQuiz(1); //TODO: quiz id should be read from route
+type Props = {
+    quiz: Quiz
+}
 
-    if (!quiz) return <></>; //TODO: Render something that indicates the quiz cannot be found
+const QuizComponent: FC<Props> = observer(({quiz}) => {
+
 
     useEffect(() => {
         QuizStore.newQuizSession(quiz);
     }, [quiz]);
 
-    const [question, setQuestion] = useState(quiz?.questions[0]);
+    const [question, setQuestion] = useState(quiz.questions[0]);
+    const [showCompletePage, setShowCompletePage] = useState(false);
 
     const currentQuestionIndex = useMemo(
         () => quiz?.questions.findIndex((q) => q === question) ?? 0,
         [quiz, question]
     );
 
-    const [isQuizCompleted, setIsQuizCompleted] = useState(false);
 
-    const [showCompletePage, setShowCompletePage] = useState(false);
 
     const changeQuestion = useCallback(
         (index: number) => {
             quiz?.questions[index] && setQuestion(quiz.questions[index]);
-
-            if (index == quiz.questions.length - 1) setIsQuizCompleted(true)
         },
         [quiz, setQuestion]
     );
 
-    if (showCompletePage) return <QuizCompletion questionAmount={quiz.questions.length} correctAnswers={QuizStore.correctAnswers} quizName={quiz.title}/>
+    if (showCompletePage) return <QuizCompletion quiz={quiz} correctAnswers={QuizStore.correctAnswers} />
 
     return (
         <>
@@ -50,13 +50,15 @@ const QuizComponent: FC = observer(() => {
                     <HStack>
                         <Button isDisabled={currentQuestionIndex == 0} colorScheme="blue" onClick={() => changeQuestion(currentQuestionIndex - 1)}>
                             Previous
-                        </Button>
-                        {isQuizCompleted ?
-                            <Button isDisabled={(QuizStore.quizSession?.answers.size ?? 0) < currentQuestionIndex+1} colorScheme="blue" onClick={() => setShowCompletePage(true)}>
+                        </Button> 
+                        {quiz.questions.length != currentQuestionIndex+1 &&
+                            <Button isDisabled={(QuizStore.quizSession?.answers.size ?? 0) < currentQuestionIndex+1}  colorScheme="blue" onClick={() => changeQuestion(currentQuestionIndex + 1)}>
+                                Next
+                            </Button>
+                        }
+                        {QuizStore.quizSession?.answers.size == quiz.questions.length && <Button isDisabled={(QuizStore.quizSession?.answers.size ?? 0) < currentQuestionIndex+1} colorScheme="green" onClick={() => setShowCompletePage(true)}>
                             Results
-                        </Button> : <Button isDisabled={(QuizStore.quizSession?.answers.size ?? 0) < currentQuestionIndex+1}  colorScheme="blue" onClick={() => changeQuestion(currentQuestionIndex + 1)}>
-                            Next
-                        </Button> }
+                        </Button>}
                     </HStack>
                 </Stack>
             )}

--- a/web/src/components/quiz/quizComponent.tsx
+++ b/web/src/components/quiz/quizComponent.tsx
@@ -48,13 +48,13 @@ const QuizComponent: FC = observer(() => {
                     }`}</Text>
                     <Text>{QuizStore.correctAnswers} correct</Text>
                     <HStack>
-                        <Button onClick={() => changeQuestion(currentQuestionIndex - 1)}>
+                        <Button isDisabled={currentQuestionIndex == 0} colorScheme="blue" onClick={() => changeQuestion(currentQuestionIndex - 1)}>
                             Previous
                         </Button>
                         {isQuizCompleted ?
-                            <Button onClick={() => setShowCompletePage(true)}>
-                            Afslut
-                        </Button> : <Button onClick={() => changeQuestion(currentQuestionIndex + 1)}>
+                            <Button isDisabled={(QuizStore.quizSession?.answers.size ?? 0) < currentQuestionIndex+1} colorScheme="blue" onClick={() => setShowCompletePage(true)}>
+                            Results
+                        </Button> : <Button isDisabled={(QuizStore.quizSession?.answers.size ?? 0) < currentQuestionIndex+1}  colorScheme="blue" onClick={() => changeQuestion(currentQuestionIndex + 1)}>
                             Next
                         </Button> }
                     </HStack>

--- a/web/src/hooks/useColors.ts
+++ b/web/src/hooks/useColors.ts
@@ -1,12 +1,12 @@
 import { useColorModeValue } from "@chakra-ui/react";
 
 export const useColors = () => {
-  const headerBg = useColorModeValue("gray.200", "gray.700");
-  const optionBg = useColorModeValue("gray.200", "gray.700");
-  const optionBgHover = useColorModeValue("gray.300", "gray.800");
+  const headerBg = useColorModeValue("blue.300", "blue.800");
+  const optionBg = useColorModeValue("blue.200", "blue.700");
+  const optionBgHover = useColorModeValue("blue.300", "blue.800");
   const optionCorrect = useColorModeValue("green.400", "green.600");
   const optionIncorrect = useColorModeValue("red.400", "red.600");
-    const primaryColorHover = useColorModeValue("gray.100", "grey.700");
+  const primaryColorHover = useColorModeValue("blue.100", "blue.700");
 
   return {
     headerBg,

--- a/web/src/pages/QuizPage.tsx
+++ b/web/src/pages/QuizPage.tsx
@@ -1,3 +1,4 @@
+import { Heading } from '@chakra-ui/layout';
 import { FC } from 'react';
 import { useParams } from 'react-router';
 import BasicLayout from '../components/layouts/basicLayout';
@@ -16,10 +17,13 @@ const QuizPage: FC = () => {
   // If no parameter is given in the URL quizId will be undefined
   const { quizId } = useParams<QuizPageProps>();
   console.log("quizId", quizId)
+  const quiz = QuizStore.getQuiz(Number(quizId)); 
 
   return (
     <BasicLayout>
-      <QuizComponent />
+      {quiz? <QuizComponent quiz={quiz}  /> : 
+      <Heading>No quiz with id {quizId} ;-(</Heading>}
+      
     </BasicLayout>
    
   );


### PR DESCRIPTION
- Added some colors (blue so far)
- Improved navigation from quiz question (forward/backwards and finally resultpage)
- Improved ResultPage
- QuizId is now read from route and "404" page shows if invalid ID
- Leaving Resultpage now clear QuizSession (fixes issue with second quiz taken shortly showing previous answer colors)

![Animation](https://user-images.githubusercontent.com/90239510/140993076-6bbb4e6d-7cdf-4aed-b51f-3446811b3cf2.gif)
