### PR TITLE
BE: docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,18 +7,21 @@ services:
     ports:
       - "8080:8080"
     networks:
-      - postgres
+      postgres:
   db:
     container_name: postgres_container
+    hostname: postgres
     image: postgres
     environment:
-      POSTGRES_PASSWORD: 12345
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-12345}
+      PGDATA: /data/postgres
     volumes:
       - postgres:/data/postgres
     ports:
       - "5432:5432"
     networks:
-      - postgres
+      postgres:
 
 networks:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+
+services:
+  app:
+    container_name: youquiz_container
+    build: .
+    ports:
+      - "8080:8080"
+    networks:
+      - postgres
+  db:
+    container_name: postgres_container
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: 12345
+    volumes:
+      - postgres:/data/postgres
+    ports:
+      - "5432:5432"
+    networks:
+      - postgres
+
+networks:
+  postgres:
+    driver: bridge
+
+volumes:
+  postgres:

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>1.18.20</version>
         </dependency>
         <!-- in memory database for testing -->
         <dependency>

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -5,7 +5,7 @@
     <session-factory>
         <property name="hibernate.dialect"> org.hibernate.dialect.PostgreSQL95Dialect</property>
         <property name="hibernate.connection.driver_class"> org.postgresql.Driver</property>
-        <property name="hibernate.connection.username">postgres</property> <property name="hibernate.connection.password">12345</property> <property name="hibernate.connection.url"> jdbc:postgresql://localhost:5432/hibernatedb</property>
+        <property name="hibernate.connection.username">postgres</property> <property name="hibernate.connection.password">12345</property> <property name="hibernate.connection.url"> jdbc:postgresql://postgres:5432/hibernatedb</property>
 
         <!-- Outputs the SQL queries, should be disabled in production -->
         <property name="hibernate.show_sql">true</property>


### PR DESCRIPTION
Docker compose file to run the docker containers for the app and the postgres database.

If the database "hibernatedb" isn't created in postgres, it should first be created by logging in to the postgres CLI and creating it with `create database hibernatedb`.

To compose and run the containers, run: `docker-compose up -d` in the root directory of the app.

It has been tested locally and worked, so hopefully it'll work on the server as well.