### PR TITLE
Be/Lazy loading

### DIFF
--- a/src/main/java/Quiz/QuizService.java
+++ b/src/main/java/Quiz/QuizService.java
@@ -9,6 +9,7 @@ import Quiz.model.Quiz;
 import User.DBUser;
 import User.dao.IUserDAO;
 import User.dao.UserDAOImpl;
+import Util.DTOUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hibernate.Hibernate;
@@ -44,7 +45,7 @@ public class QuizService {
     @POST
     @Consumes("application/json")
     public Response createQuiz(QuizDto dto){
-        Quiz quiz = new ObjectMapper().convertValue(dto, new TypeReference<Quiz>(){});
+        Quiz quiz = DTOUtil.convert(dto, new TypeReference<Quiz>(){});
 
         //TODO: Modify so that it fetches the user that made the request. Id from token claims.
         //DBUser creator = userDAO.getUser(3);
@@ -58,7 +59,7 @@ public class QuizService {
     @PUT
     @Consumes("application/json")
     public Response updateQuiz(@QueryParam("id") int id, QuizIdDto dto) {
-        Quiz newQuiz = new ObjectMapper().convertValue(dto, new TypeReference<Quiz>(){});
+        Quiz newQuiz = DTOUtil.convert(dto, new TypeReference<Quiz>() {});
         quizDAO.updateQuiz(id, newQuiz);
         return Response.status(Response.Status.OK).entity("Quiz updated").build();
     }

--- a/src/main/java/Quiz/QuizService.java
+++ b/src/main/java/Quiz/QuizService.java
@@ -29,8 +29,7 @@ public class QuizService {
     @Path("{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getQuiz(@PathParam("id") int id){
-        Quiz quiz = quizDAO.getQuiz(id);
-        QuizIdDto dto = new ObjectMapper().convertValue(quiz, new TypeReference<QuizIdDto>(){});
+        QuizIdDto dto = quizDAO.getQuiz(id);
         return Response.status(Response.Status.OK).entity(dto).build();
     }
 
@@ -38,7 +37,6 @@ public class QuizService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getAllQuizes(){
         Collection<QuizIdDto> quizzes = quizDAO.getAllQuizzes();
-        //QuizIdDto dto = new ObjectMapper().convertValue(quiz, new TypeReference<QuizIdDto>(){});
         return Response.status(Response.Status.OK).entity(quizzes).build();
     }
 

--- a/src/main/java/Quiz/QuizService.java
+++ b/src/main/java/Quiz/QuizService.java
@@ -4,13 +4,16 @@ import Quiz.dao.IQuizDAO;
 import Quiz.dao.QuizDaoImpl;
 import Quiz.dto.QuizDto;
 import Quiz.dto.QuizIdDto;
+import Quiz.model.Question;
 import Quiz.model.Quiz;
 import User.DBUser;
 import User.dao.IUserDAO;
 import User.dao.UserDAOImpl;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hibernate.Hibernate;
 
+import javax.transaction.Transactional;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -34,7 +37,7 @@ public class QuizService {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getAllQuizes(){
-        Collection<Quiz> quizzes = quizDAO.getAllQuizzes();
+        Collection<QuizIdDto> quizzes = quizDAO.getAllQuizzes();
         //QuizIdDto dto = new ObjectMapper().convertValue(quiz, new TypeReference<QuizIdDto>(){});
         return Response.status(Response.Status.OK).entity(quizzes).build();
     }

--- a/src/main/java/Quiz/dao/IQuizDAO.java
+++ b/src/main/java/Quiz/dao/IQuizDAO.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 
 public interface IQuizDAO {
 
-    Quiz getQuiz(int id);
+    QuizIdDto getQuiz(int id);
     Collection<QuizIdDto> getAllQuizzes();
     int addQuiz(Quiz quiz, int userId);
     void updateQuiz(int id, Quiz newQuiz);

--- a/src/main/java/Quiz/dao/IQuizDAO.java
+++ b/src/main/java/Quiz/dao/IQuizDAO.java
@@ -1,5 +1,6 @@
 package Quiz.dao;
 
+import Quiz.dto.QuizIdDto;
 import Quiz.model.Quiz;
 
 import java.util.Collection;
@@ -7,7 +8,7 @@ import java.util.Collection;
 public interface IQuizDAO {
 
     Quiz getQuiz(int id);
-    Collection<Quiz> getAllQuizzes();
+    Collection<QuizIdDto> getAllQuizzes();
     int addQuiz(Quiz quiz, int userId);
     void updateQuiz(int id, Quiz newQuiz);
     void deleteQuiz(int id);

--- a/src/main/java/Quiz/dao/QuizDaoImpl.java
+++ b/src/main/java/Quiz/dao/QuizDaoImpl.java
@@ -1,9 +1,15 @@
 package Quiz.dao;
 
+import Quiz.dto.QuizDto;
+import Quiz.dto.QuizIdDto;
+import Quiz.model.Question;
 import Quiz.model.Quiz;
 import User.DBUser;
 import Util.DAObase;
 import Util.HibernateUtil;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -13,8 +19,10 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 
 public class QuizDaoImpl extends DAObase implements IQuizDAO {
     @Override
@@ -35,13 +43,16 @@ public class QuizDaoImpl extends DAObase implements IQuizDAO {
     }
 
     @Override
-    public Collection<Quiz> getAllQuizzes() {
+    public Collection<QuizIdDto> getAllQuizzes() {
+        List<QuizIdDto> quizzes = new ArrayList<>();
         try (Session session = HibernateUtil.getSession()) {
-            return HibernateUtil.loadAllData(Quiz.class, session);
+            HibernateUtil.loadAllData(Quiz.class, session).forEach(quiz -> {
+                quizzes.add(new ObjectMapper().convertValue(quiz, new TypeReference<QuizIdDto>(){}));
+            });
         } catch (HibernateException e) {
             e.printStackTrace();
         }
-        return null;
+        return quizzes;
     }
 
     @Override

--- a/src/main/java/Quiz/dao/QuizDaoImpl.java
+++ b/src/main/java/Quiz/dao/QuizDaoImpl.java
@@ -21,21 +21,20 @@ import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 
 public class QuizDaoImpl extends DAObase implements IQuizDAO {
     @Override
-    public Quiz getQuiz(int id) {
+    public QuizIdDto getQuiz(int id) {
         try (Session session = HibernateUtil.getSession()) {
             Quiz quiz = session.get(Quiz.class, id);
 
             if (quiz == null)
                 throw new NotFoundException("Quiz not found. Id: " + id);
 
-            //quiz.setQuestions(new HashSet<>(quiz.getQuestions()));
+            QuizIdDto dto = new ObjectMapper().convertValue(quiz, new TypeReference<QuizIdDto>(){});
 
-            return quiz;
+            return dto;
         } catch (HibernateException e) {
             e.printStackTrace();
         }
@@ -44,15 +43,16 @@ public class QuizDaoImpl extends DAObase implements IQuizDAO {
 
     @Override
     public Collection<QuizIdDto> getAllQuizzes() {
-        List<QuizIdDto> quizzes = new ArrayList<>();
         try (Session session = HibernateUtil.getSession()) {
+            List<QuizIdDto> quizzes = new ArrayList<>();
             HibernateUtil.loadAllData(Quiz.class, session).forEach(quiz -> {
                 quizzes.add(new ObjectMapper().convertValue(quiz, new TypeReference<QuizIdDto>(){}));
             });
+            return quizzes;
         } catch (HibernateException e) {
             e.printStackTrace();
+            throw new InternalServerErrorException("An exception was thrown when fetching quizzes.");
         }
-        return quizzes;
     }
 
     @Override
@@ -61,7 +61,6 @@ public class QuizDaoImpl extends DAObase implements IQuizDAO {
         Session session = HibernateUtil.getSession();
         try {
             tx = session.beginTransaction();
-
 
             //TODO: Change back to the commented out code
             //DBUser user = session.get(DBUser.class, userId);

--- a/src/main/java/Quiz/dto/QuizDto.java
+++ b/src/main/java/Quiz/dto/QuizDto.java
@@ -1,5 +1,6 @@
 package Quiz.dto;
 
+import User.dto.DBUserDto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
@@ -11,4 +12,6 @@ public @Data class QuizDto {
     private String category;
     private String description;
     private Collection<QuestionDto> questions;
+    private DBUserDto createdBy;
+    private int createdById;
 }

--- a/src/main/java/Quiz/dto/QuizIdDto.java
+++ b/src/main/java/Quiz/dto/QuizIdDto.java
@@ -1,6 +1,6 @@
 package Quiz.dto;
 
-import User.DBUserDto;
+import User.dto.DBUserDto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
@@ -13,4 +13,6 @@ public @Data class QuizIdDto {
     private String category;
     private String description;
     private Collection<QuestionIdDto> questions;
+    private DBUserDto createdBy;
+    private int createdById;
 }

--- a/src/main/java/Quiz/dto/QuizIdDto.java
+++ b/src/main/java/Quiz/dto/QuizIdDto.java
@@ -1,5 +1,6 @@
 package Quiz.dto;
 
+import User.DBUserDto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 

--- a/src/main/java/Quiz/model/Question.java
+++ b/src/main/java/Quiz/model/Question.java
@@ -29,7 +29,7 @@ public @Data class Question {
     @ToString.Exclude
     private Quiz quiz;
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonManagedReference
     private Collection<QuestionOption> options;
 }

--- a/src/main/java/Quiz/model/Quiz.java
+++ b/src/main/java/Quiz/model/Quiz.java
@@ -37,7 +37,7 @@ public @Data class Quiz {
     @ToString.Exclude
     private DBUser createdBy;
 
-    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonManagedReference
     private Collection<Question> questions = new ArrayList<>();
 

--- a/src/main/java/Quiz/model/Quiz.java
+++ b/src/main/java/Quiz/model/Quiz.java
@@ -37,6 +37,9 @@ public @Data class Quiz {
     @ToString.Exclude
     private DBUser createdBy;
 
+    @Column(name = "user_id_only")
+    private int createdById;
+
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonManagedReference
     private Collection<Question> questions = new ArrayList<>();

--- a/src/main/java/User/DBUser.java
+++ b/src/main/java/User/DBUser.java
@@ -22,7 +22,7 @@ class DBUser {
     @Column(name = "first_name")
     private String first_name;
 
-    @OneToMany(mappedBy = "createdBy", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "createdBy", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonManagedReference
     private Collection<Quiz> quizzes = new ArrayList<>();
 

--- a/src/main/java/User/UserService.java
+++ b/src/main/java/User/UserService.java
@@ -2,6 +2,9 @@ package User;
 
 import User.dao.IUserDAO;
 import User.dao.UserDAOImpl;
+import User.dto.DBUserDto;
+import User.dto.DBUserQuizzesDto;
+import Util.DTOUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -19,21 +22,21 @@ public class UserService {
     @Path("{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getUser(@PathParam("id") int id){
-        DBUserDto user = userDAO.getUser(id);
+        DBUserQuizzesDto user = userDAO.getUser(id);
         return Response.status(Response.Status.OK).entity(user).build();
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getAllUsers(){
-        Collection<DBUserDto> users = userDAO.getAllUsers();
+        Collection<DBUserQuizzesDto> users = userDAO.getAllUsers();
         return Response.status(Response.Status.OK).entity(users).build();
     }
 
     @POST
     @Consumes("application/json")
     public Response createUser(DBUserDto dto){
-        DBUser user = new ObjectMapper().convertValue(dto, new TypeReference<DBUser>(){});
+        DBUser user = DTOUtil.convert(dto, new TypeReference<DBUser>(){});
         int id = userDAO.addUser(user);
         return Response.status(Response.Status.CREATED).entity(id).build();
     }
@@ -41,7 +44,7 @@ public class UserService {
     @PUT
     @Consumes("application/json")
     public Response updateUser(@QueryParam("id") int id, DBUserDto dto) {
-        DBUser newUser = new ObjectMapper().convertValue(dto, new TypeReference<DBUser>(){});
+        DBUser newUser = DTOUtil.convert(dto, new TypeReference<DBUser>(){});
         userDAO.updateUser(id, newUser);
         return Response.status(Response.Status.OK).entity("User updated").build();
     }

--- a/src/main/java/User/UserService.java
+++ b/src/main/java/User/UserService.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Collection;
 
 @Path("user")
 public class UserService {
@@ -18,9 +19,15 @@ public class UserService {
     @Path("{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getUser(@PathParam("id") int id){
-        DBUser user = userDAO.getUser(id);
-        DBUserDto dto = new ObjectMapper().convertValue(user, new TypeReference<DBUserDto>(){});
-        return Response.status(Response.Status.OK).entity(dto).build();
+        DBUserDto user = userDAO.getUser(id);
+        return Response.status(Response.Status.OK).entity(user).build();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAllUsers(){
+        Collection<DBUserDto> users = userDAO.getAllUsers();
+        return Response.status(Response.Status.OK).entity(users).build();
     }
 
     @POST

--- a/src/main/java/User/dao/IUserDAO.java
+++ b/src/main/java/User/dao/IUserDAO.java
@@ -1,14 +1,15 @@
 package User.dao;
 
 import User.DBUser;
-import User.DBUserDto;
+import User.dto.DBUserDto;
+import User.dto.DBUserQuizzesDto;
 
 import java.util.Collection;
 
 public interface IUserDAO {
 
-    DBUserDto getUser(int id);
-    Collection<DBUserDto> getAllUsers();
+    DBUserQuizzesDto getUser(int id);
+    Collection<DBUserQuizzesDto> getAllUsers();
     int addUser(DBUser user);
     void updateUser(int id, DBUser newUser);
     void deleteUser(int id);

--- a/src/main/java/User/dao/IUserDAO.java
+++ b/src/main/java/User/dao/IUserDAO.java
@@ -1,10 +1,14 @@
 package User.dao;
 
 import User.DBUser;
+import User.DBUserDto;
+
+import java.util.Collection;
 
 public interface IUserDAO {
 
-    DBUser getUser(int id);
+    DBUserDto getUser(int id);
+    Collection<DBUserDto> getAllUsers();
     int addUser(DBUser user);
     void updateUser(int id, DBUser newUser);
     void deleteUser(int id);

--- a/src/main/java/User/dao/UserDAOImpl.java
+++ b/src/main/java/User/dao/UserDAOImpl.java
@@ -1,13 +1,11 @@
 package User.dao;
 
-import Quiz.dto.QuizIdDto;
-import Quiz.model.Quiz;
 import User.DBUser;
-import User.DBUserDto;
+import User.dto.DBUserQuizzesDto;
 import Util.DAObase;
+import Util.DTOUtil;
 import Util.HibernateUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -20,23 +18,23 @@ import java.util.List;
 
 public class UserDAOImpl extends DAObase implements IUserDAO {
     @Override
-    public DBUserDto getUser(int id) {
+    public DBUserQuizzesDto getUser(int id) {
         try (Session session = HibernateUtil.getSession()) {
             DBUser user = session.get(DBUser.class, id);
 
             if (user == null)
                 throw new NotFoundException("User not found. Id: " + id);
 
-            return new ObjectMapper().convertValue(user, new TypeReference<DBUserDto>(){});
+            return DTOUtil.convert(user, new TypeReference<DBUserQuizzesDto>(){});
         }
     }
 
     @Override
-    public Collection<DBUserDto> getAllUsers() {
+    public Collection<DBUserQuizzesDto> getAllUsers() {
         try (Session session = HibernateUtil.getSession()) {
-            List<DBUserDto> users = new ArrayList<>();
+            List<DBUserQuizzesDto> users = new ArrayList<>();
             HibernateUtil.loadAllData(DBUser.class, session).forEach(user -> {
-                users.add(new ObjectMapper().convertValue(user, new TypeReference<DBUserDto>(){}));
+                users.add(DTOUtil.convert(user, new TypeReference<DBUserQuizzesDto>(){}));
             });
             return users;
         } catch (HibernateException e) {

--- a/src/main/java/User/dao/UserDAOImpl.java
+++ b/src/main/java/User/dao/UserDAOImpl.java
@@ -1,26 +1,47 @@
 package User.dao;
 
+import Quiz.dto.QuizIdDto;
 import Quiz.model.Quiz;
 import User.DBUser;
+import User.DBUserDto;
 import Util.DAObase;
 import Util.HibernateUtil;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class UserDAOImpl extends DAObase implements IUserDAO {
     @Override
-    public DBUser getUser(int id) {
+    public DBUserDto getUser(int id) {
         try (Session session = HibernateUtil.getSession()) {
             DBUser user = session.get(DBUser.class, id);
 
             if (user == null)
                 throw new NotFoundException("User not found. Id: " + id);
 
-            return user;
+            return new ObjectMapper().convertValue(user, new TypeReference<DBUserDto>(){});
+        }
+    }
+
+    @Override
+    public Collection<DBUserDto> getAllUsers() {
+        try (Session session = HibernateUtil.getSession()) {
+            List<DBUserDto> users = new ArrayList<>();
+            HibernateUtil.loadAllData(DBUser.class, session).forEach(user -> {
+                users.add(new ObjectMapper().convertValue(user, new TypeReference<DBUserDto>(){}));
+            });
+            return users;
+        } catch (HibernateException e) {
+            e.printStackTrace();
+            throw new InternalServerErrorException("An exception was thrown when fetching users");
         }
     }
 

--- a/src/main/java/User/dto/DBUserDto.java
+++ b/src/main/java/User/dto/DBUserDto.java
@@ -1,16 +1,12 @@
-package User;
+package User.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import Quiz.dto.QuizIdDto;
 import lombok.Data;
-
-import java.util.Collection;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public @Data class DBUserDto {
 
     private int id;
     private String first_name;
-    private Collection<QuizIdDto> quizzes;
 }

--- a/src/main/java/User/dto/DBUserQuizzesDto.java
+++ b/src/main/java/User/dto/DBUserQuizzesDto.java
@@ -1,0 +1,16 @@
+package User.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import Quiz.dto.QuizIdDto;
+import lombok.Data;
+
+import java.util.Collection;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public @Data class DBUserQuizzesDto {
+
+    private int id;
+    private String first_name;
+    private Collection<QuizIdDto> quizzes;
+}

--- a/src/main/java/Util/DTOUtil.java
+++ b/src/main/java/Util/DTOUtil.java
@@ -1,0 +1,14 @@
+package Util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class DTOUtil {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static <T, U> T convert(Object o, TypeReference<U> ref) {
+        return mapper.convertValue(o, ref);
+    }
+
+}

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -7,7 +7,7 @@
         <property name="hibernate.connection.driver_class"> org.postgresql.Driver</property>
         <property name="hibernate.connection.username">postgres</property>
         <property name="hibernate.connection.password">12345</property>
-        <property name="hibernate.connection.url"> jdbc:postgresql://srv-captain--youquiz-db-db:5432/hibernatedb</property>
+        <property name="hibernate.connection.url"> jdbc:postgresql://localhost:5432/hibernatedb</property>
 
         <!-- Outputs the SQL queries, should be disabled in production -->
         <property name="hibernate.show_sql">true</property>

--- a/src/test/java/Quiz/dao/QuizDaoImplTest.java
+++ b/src/test/java/Quiz/dao/QuizDaoImplTest.java
@@ -1,5 +1,6 @@
 package Quiz.dao;
 
+import Quiz.dto.QuizIdDto;
 import Quiz.model.Quiz;
 import User.DBUser;
 import User.dao.IUserDAO;
@@ -36,11 +37,11 @@ class QuizDaoImplTest {
 
     @Test
     void getQuiz() {
-        Quiz quiz = quizDAO.getQuiz(3);
+        QuizIdDto quiz = quizDAO.getQuiz(3);
         assertEquals("title 1", quiz.getTitle());
         assertEquals("description 1", quiz.getDescription());
         assertEquals("category 1", quiz.getCategory());
-        assertEquals(1, quiz.getCreatedBy().getId());
+        //assertEquals(1, quiz.getCreatedBy().getId());
 
         assertThrows(NotFoundException.class, () -> {
             quizDAO.getQuiz(1000);
@@ -61,7 +62,7 @@ class QuizDaoImplTest {
     void addAndGetQuiz() {
         int id = quizDAO.addQuiz(new Quiz("title 3", "category 3", "description 3"), 1);
         System.out.println("ID ER: " + id);
-        Quiz quiz = quizDAO.getQuiz(id);
+        QuizIdDto quiz = quizDAO.getQuiz(id);
         assertEquals("title 3", quiz.getTitle());
         assertEquals("description 3", quiz.getDescription());
         assertEquals("category 3", quiz.getCategory());
@@ -70,7 +71,7 @@ class QuizDaoImplTest {
     @Test
     void updateQuiz() {
         quizDAO.updateQuiz(5, new Quiz("new title", "new category", "new description"));
-        Quiz quiz = quizDAO.getQuiz(5);
+        QuizIdDto quiz = quizDAO.getQuiz(5);
         assertEquals("new title", quiz.getTitle());
         assertEquals("new description", quiz.getDescription());
         assertEquals("new category", quiz.getCategory());

--- a/src/test/java/Quiz/dao/QuizDaoImplTest.java
+++ b/src/test/java/Quiz/dao/QuizDaoImplTest.java
@@ -41,7 +41,7 @@ class QuizDaoImplTest {
         assertEquals("title 1", quiz.getTitle());
         assertEquals("description 1", quiz.getDescription());
         assertEquals("category 1", quiz.getCategory());
-        //assertEquals(1, quiz.getCreatedBy().getId());
+        assertEquals(1, quiz.getCreatedBy().getId());
 
         assertThrows(NotFoundException.class, () -> {
             quizDAO.getQuiz(1000);

--- a/src/test/java/User/dao/UserDatoImplTest.java
+++ b/src/test/java/User/dao/UserDatoImplTest.java
@@ -1,6 +1,7 @@
 package User.dao;
 
 import User.DBUser;
+import User.DBUserDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ public class UserDatoImplTest {
 
     @Test
     void getUser() {
-        DBUser user = userDAO.getUser(1);
+        DBUserDto user = userDAO.getUser(1);
         assertEquals("test user 1", user.getFirst_name());
 
         assertThrows(NotFoundException.class, () -> {
@@ -50,14 +51,14 @@ public class UserDatoImplTest {
     @Test
     void addAndGetUser() {
         int id = userDAO.addUser(new DBUser("new user"));
-        DBUser user = userDAO.getUser(id);
+        DBUserDto user = userDAO.getUser(id);
         assertEquals("new user", user.getFirst_name());
     }
 
     @Test
     void updateUser() {
         userDAO.updateUser(2, new DBUser("new name"));
-        DBUser user = userDAO.getUser(2);
+        DBUserDto user = userDAO.getUser(2);
         assertEquals("new name", user.getFirst_name());
     }
 

--- a/src/test/java/User/dao/UserDatoImplTest.java
+++ b/src/test/java/User/dao/UserDatoImplTest.java
@@ -1,7 +1,8 @@
 package User.dao;
 
 import User.DBUser;
-import User.DBUserDto;
+import User.dto.DBUserDto;
+import User.dto.DBUserQuizzesDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ public class UserDatoImplTest {
 
     @Test
     void getUser() {
-        DBUserDto user = userDAO.getUser(1);
+        DBUserQuizzesDto user = userDAO.getUser(1);
         assertEquals("test user 1", user.getFirst_name());
 
         assertThrows(NotFoundException.class, () -> {
@@ -51,14 +52,14 @@ public class UserDatoImplTest {
     @Test
     void addAndGetUser() {
         int id = userDAO.addUser(new DBUser("new user"));
-        DBUserDto user = userDAO.getUser(id);
+        DBUserQuizzesDto user = userDAO.getUser(id);
         assertEquals("new user", user.getFirst_name());
     }
 
     @Test
     void updateUser() {
         userDAO.updateUser(2, new DBUser("new name"));
-        DBUserDto user = userDAO.getUser(2);
+        DBUserQuizzesDto user = userDAO.getUser(2);
         assertEquals("new name", user.getFirst_name());
     }
 

--- a/web/src/components/quiz/QuizSelection/quizSelection.tsx
+++ b/web/src/components/quiz/QuizSelection/quizSelection.tsx
@@ -36,8 +36,8 @@ const QuizSelection: FC = observer(() => {
       <Heading>Select a quiz</Heading>
       <SimpleGrid width="full" minChildWidth="240px" spacing="10px">
         {QuizStore.quizes.map((quiz) => (
-          <Center>
-            <QuizSelectionItem key={quiz.id} quiz={quiz} />
+          <Center key={quiz.id}>
+            <QuizSelectionItem quiz={quiz} />
           </Center>
         ))}
       </SimpleGrid>

--- a/web/src/components/quiz/QuizSelection/quizSelectionItem.tsx
+++ b/web/src/components/quiz/QuizSelection/quizSelectionItem.tsx
@@ -1,34 +1,42 @@
-import { Box, Flex, Heading, List, ListItem, Stack } from '@chakra-ui/layout';
-import { observer } from 'mobx-react-lite';
-import { FC } from 'react';
-import { Link } from 'react-router-dom';
-import { useColors } from '../../../hooks/useColors';
-import {Quiz} from "../../../model/quiz";
+import { Box, Flex, Heading, List, ListItem, Stack } from "@chakra-ui/layout";
+import { observer } from "mobx-react-lite";
+import { FC } from "react";
+import { Link } from "react-router-dom";
+import { useColors } from "../../../hooks/useColors";
+import { Quiz } from "../../../model/quiz";
 
 interface Props {
-    quiz: Quiz
+  quiz: Quiz;
 }
 
 const QuizSelectionItem: FC<Props> = observer(({ quiz }) => {
-    const { headerBg, primaryColorHover } = useColors();
+  const { headerBg, primaryColorHover } = useColors();
 
-
-    return (
-        <Link to={"quiz/"+quiz.id}>
-            <Box cursor="pointer" _hover={{ bgColor: primaryColorHover }} width="250px" h="fit-content" bgColor={headerBg} m={5} p={2} borderRadius="md" boxShadow="xl" >
-                <Stack borderRadius={5} borderColor="black" spacing={5} key={quiz.id}>
-                    <Heading size="md">{quiz.title}</Heading>
-                    <List>
-                        <ListItem>Category: {quiz.category}</ListItem>
-                        <ListItem>Description: {quiz.description}</ListItem>
-                        <ListItem>Created By: {quiz.createdBy}</ListItem>
-                        <ListItem>Category By: {quiz.category}</ListItem>
-                    </List>
-                </Stack>
-            </Box>
-        </Link>
-
-    );
+  return (
+    <Link to={"quiz/" + quiz.id}>
+      <Box
+        cursor="pointer"
+        _hover={{ bgColor: primaryColorHover }}
+        width="250px"
+        h="fit-content"
+        bgColor={headerBg}
+        m={5}
+        p={2}
+        borderRadius="md"
+        boxShadow="xl"
+      >
+        <Stack borderRadius={5} borderColor="black" spacing={5} key={quiz.id}>
+          <Heading size="md">{quiz.title}</Heading>
+          <List>
+            <ListItem>Category: {quiz.category}</ListItem>
+            <ListItem>Description: {quiz.description}</ListItem>
+            <ListItem>Created By: {quiz.createdBy?.first_name}</ListItem>
+            <ListItem>Category By: {quiz.category}</ListItem>
+          </List>
+        </Stack>
+      </Box>
+    </Link>
+  );
 });
 
 export default QuizSelectionItem;

--- a/web/src/components/quiz/optionComponent.tsx
+++ b/web/src/components/quiz/optionComponent.tsx
@@ -21,7 +21,7 @@ const Option: FC<optionProps> = ({ answer, option, onClick, i }) => {
     () =>
       !answer
         ? optionBg
-        : option.isCorrect
+        : option.correct
         ? optionCorrect
         : answer === option
         ? optionIncorrect
@@ -37,9 +37,7 @@ const Option: FC<optionProps> = ({ answer, option, onClick, i }) => {
       justifyContent="start"
       onClick={(e) => onClick(option)}
     >
-      <Stack
-          direction={"row"}
-          spacing={6}>
+      <Stack direction={"row"} spacing={6}>
         <Text>{alphabet[i]}</Text>
         <Text>{option.text}</Text>
       </Stack>

--- a/web/src/model/questionOption.ts
+++ b/web/src/model/questionOption.ts
@@ -1,4 +1,4 @@
 export type QuestionOption = {
   text: string;
-  isCorrect: boolean;
+  correct: boolean;
 };

--- a/web/src/model/quiz.ts
+++ b/web/src/model/quiz.ts
@@ -1,10 +1,12 @@
 import { Question } from "./question";
+import { User } from "./user";
 
 export type Quiz = {
   id: number;
   title?: string;
   category?: string;
   description?: string;
-  createdBy: number; // user ID
+  createdBy?: User; // user ID
+  createdById: number;
   questions: Question[];
 };

--- a/web/src/model/user.ts
+++ b/web/src/model/user.ts
@@ -1,7 +1,7 @@
 import { Quiz } from "./quiz";
 
 export type User = {
-    id: number,
-    firstName: string,
-    quizes: Quiz[]
-}
+  id: number;
+  first_name: string;
+  quizzes?: Quiz[];
+};

--- a/web/src/pages/ServiceTestPage.tsx
+++ b/web/src/pages/ServiceTestPage.tsx
@@ -1,71 +1,77 @@
-import { Button } from '@chakra-ui/button';
-import { HStack, VStack } from '@chakra-ui/layout';
-import { FC} from 'react';
-import BasicLayout from '../components/layouts/basicLayout';
-import { genQuizClient, genUserClient } from '../services/apiClients';
-import { QuizStore } from '../stores/quizStore';
+import { Button } from "@chakra-ui/button";
+import { HStack, VStack } from "@chakra-ui/layout";
+import { FC } from "react";
+import BasicLayout from "../components/layouts/basicLayout";
+import { genQuizClient, genUserClient } from "../services/apiClients";
+import { QuizStore } from "../stores/quizStore";
 
 const Home: FC = () => {
+  const getQuiz = async () => {
+    const quizClient = await genQuizClient();
+    quizClient.getQuiz(1);
+  };
 
-    const getQuiz = async () => {
-      const quizClient = await genQuizClient()
-      quizClient.getQuiz(1)
-    }
+  const createQuiz = async () => {
+    const quizClient = await genQuizClient();
+    quizClient.createQuiz(QuizStore.quizes[0]);
+  };
 
-    const createQuiz = async () => {
-      const quizClient = await genQuizClient()
-      quizClient.createQuiz(QuizStore.quizes[0])
-    }
+  const updateQuiz = async () => {
+    const quizClient = await genQuizClient();
+    quizClient.updateQuiz(1, QuizStore.quizes[1]);
+  };
 
-    const updateQuiz = async () => {
-      const quizClient = await genQuizClient()
-      quizClient.updateQuiz(1, QuizStore.quizes[1])
-    }
+  const deleteQuiz = async () => {
+    const quizClient = await genQuizClient();
+    quizClient.deleteQuiz(1);
+  };
 
-    const deleteQuiz = async () => {
-      const quizClient = await genQuizClient()
-      quizClient.deleteQuiz(1)
-   }
-
-   const getUser = async () => {
-    const userClient = await genUserClient()
-    userClient.getUser(1)
-  }
+  const getUser = async () => {
+    const userClient = await genUserClient();
+    userClient.getUser(1);
+  };
 
   const createUser = async () => {
-    const userClient = await genUserClient()
-    userClient.createUser({id: 1, firstName: 'test', quizes: QuizStore.quizes})
-  }
+    const userClient = await genUserClient();
+    userClient.createUser({
+      id: 1,
+      first_name: "test",
+      quizzes: QuizStore.quizes,
+    });
+  };
 
   const updateUser = async () => {
-    const userClient = await genUserClient()
-    userClient.updateUser(1, {id: 2, firstName: 'test2', quizes: QuizStore.quizes} )
-  }
+    const userClient = await genUserClient();
+    userClient.updateUser(1, {
+      id: 2,
+      first_name: "test2",
+      quizzes: QuizStore.quizes,
+    });
+  };
 
   const deleteUser = async () => {
-    const userClient = await genUserClient()
-    userClient.deleteUser(1)
- }
-    
+    const userClient = await genUserClient();
+    userClient.deleteUser(1);
+  };
 
   return (
     <BasicLayout>
       <VStack spacing={2}>
         <HStack spacing={2}>
-            <Button onClick={getQuiz} >Get Quiz</Button>
-            <Button onClick={createQuiz} >Create Quiz</Button>
-            <Button onClick={updateQuiz} >Update Quiz</Button>
-            <Button onClick={deleteQuiz} >Delete Quiz</Button>
+          <Button onClick={getQuiz}>Get Quiz</Button>
+          <Button onClick={createQuiz}>Create Quiz</Button>
+          <Button onClick={updateQuiz}>Update Quiz</Button>
+          <Button onClick={deleteQuiz}>Delete Quiz</Button>
         </HStack>
         <HStack spacing={2}>
-            <Button onClick={getUser} >Get User</Button>
-            <Button onClick={createUser} >Create User</Button>
-            <Button onClick={updateUser} >Update User</Button>
-            <Button onClick={deleteUser} >Delete User</Button>
+          <Button onClick={getUser}>Get User</Button>
+          <Button onClick={createUser}>Create User</Button>
+          <Button onClick={updateUser}>Update User</Button>
+          <Button onClick={deleteUser}>Delete User</Button>
         </HStack>
-        </VStack>
+      </VStack>
     </BasicLayout>
   );
-}
+};
 
 export default Home;

--- a/web/src/stores/quizStore.ts
+++ b/web/src/stores/quizStore.ts
@@ -48,7 +48,7 @@ export class QuizStoreImpl {
   get correctAnswers(): number {
     if (!this.quizSession) return 0;
     return Array.from(this.quizSession.answers.values()).reduce(
-      (acc, answer) => (answer.isCorrect ? acc + 1 : acc),
+      (acc, answer) => (answer.correct ? acc + 1 : acc),
       0
     );
   }
@@ -57,137 +57,138 @@ export class QuizStoreImpl {
 export const QuizStore = new QuizStoreImpl();
 
 //Create a test quiz. Only temporary for mock data.
-const testQuiz1: Quiz = {
-  id: 1,
-  title: "DevOps quizzen",
-  category: "DevOps",
-  description: "En quiz om DevOps",
-  createdBy: 1,
-  questions: [
-    {
-      description: "Hvilket problem forsøger DevOps at løse?",
-      options: [
-        {
-          text: "Lange deployment cycles",
-          isCorrect: false,
-        },
-        {
-          text: "Skrøbelig infrastruktur og applikationskode",
-          isCorrect: false,
-        },
-        {
-          text: "Ineffektive eller uddaterede applikationer",
-          isCorrect: false,
-        },
-        {
-          text: "Alle ovenstående",
-          isCorrect: true,
-        },
-      ],
-    },
-    {
-      description: "nyt spørgsmål",
-      options: [
-        {
-          text: "test",
-          isCorrect: false,
-        },
-        {
-          text: "test2",
-          isCorrect: true,
-        },
-      ],
-    },
-  ],
-};
-const testQuiz2: Quiz = {
-  id: 2,
-  title: "DevOps quizzen",
-  category: "DevOps",
-  description: "En quiz om DevOps",
-  createdBy: 1,
-  questions: [
-    {
-      description: "Hvilket problem forsøger DevOps at løse?",
-      options: [
-        {
-          text: "Lange deployment cycles",
-          isCorrect: false,
-        },
-        {
-          text: "Skrøbelig infrastruktur og applikationskode",
-          isCorrect: false,
-        },
-        {
-          text: "Ineffektive eller uddaterede applikationer",
-          isCorrect: false,
-        },
-        {
-          text: "Alle ovenstående",
-          isCorrect: true,
-        },
-      ],
-    },
-    {
-      description: "nyt spørgsmål",
-      options: [
-        {
-          text: "test",
-          isCorrect: false,
-        },
-        {
-          text: "test2",
-          isCorrect: true,
-        },
-      ],
-    },
-  ],
-};
-const testQuiz3: Quiz = {
-  id: 3,
-  title: "DevOps quizzen",
-  category: "DevOps",
-  description: "En quiz om DevOps",
-  createdBy: 1,
-  questions: [
-    {
-      description: "Hvilket problem forsøger DevOps at løse?",
-      options: [
-        {
-          text: "Lange deployment cycles",
-          isCorrect: false,
-        },
-        {
-          text: "Skrøbelig infrastruktur og applikationskode",
-          isCorrect: false,
-        },
-        {
-          text: "Ineffektive eller uddaterede applikationer",
-          isCorrect: false,
-        },
-        {
-          text: "Alle ovenstående",
-          isCorrect: true,
-        },
-      ],
-    },
-    {
-      description: "nyt spørgsmål",
-      options: [
-        {
-          text: "test",
-          isCorrect: false,
-        },
-        {
-          text: "test2",
-          isCorrect: true,
-        },
-      ],
-    },
-  ],
-};
 
-//Add test quiz to store. Only temporary for mock data.
-QuizStore.addQuiz(testQuiz1);
-QuizStore.addQuiz(testQuiz2);
-QuizStore.addQuiz(testQuiz3);
+// const testQuiz1: Quiz = {
+//   id: 1,
+//   title: "DevOps quizzen",
+//   category: "DevOps",
+//   description: "En quiz om DevOps",
+//   createdBy: 1,
+//   questions: [
+//     {
+//       description: "Hvilket problem forsøger DevOps at løse?",
+//       options: [
+//         {
+//           text: "Lange deployment cycles",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "Skrøbelig infrastruktur og applikationskode",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "Ineffektive eller uddaterede applikationer",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "Alle ovenstående",
+//           isCorrect: true,
+//         },
+//       ],
+//     },
+//     {
+//       description: "nyt spørgsmål",
+//       options: [
+//         {
+//           text: "test",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "test2",
+//           isCorrect: true,
+//         },
+//       ],
+//     },
+//   ],
+// };
+// const testQuiz2: Quiz = {
+//   id: 2,
+//   title: "DevOps quizzen",
+//   category: "DevOps",
+//   description: "En quiz om DevOps",
+//   createdBy: 1,
+//   questions: [
+//     {
+//       description: "Hvilket problem forsøger DevOps at løse?",
+//       options: [
+//         {
+//           text: "Lange deployment cycles",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "Skrøbelig infrastruktur og applikationskode",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "Ineffektive eller uddaterede applikationer",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "Alle ovenstående",
+//           isCorrect: true,
+//         },
+//       ],
+//     },
+//     {
+//       description: "nyt spørgsmål",
+//       options: [
+//         {
+//           text: "test",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "test2",
+//           isCorrect: true,
+//         },
+//       ],
+//     },
+//   ],
+// };
+// const testQuiz3: Quiz = {
+//   id: 3,
+//   title: "DevOps quizzen",
+//   category: "DevOps",
+//   description: "En quiz om DevOps",
+//   createdBy: 1,
+//   questions: [
+//     {
+//       description: "Hvilket problem forsøger DevOps at løse?",
+//       options: [
+//         {
+//           text: "Lange deployment cycles",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "Skrøbelig infrastruktur og applikationskode",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "Ineffektive eller uddaterede applikationer",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "Alle ovenstående",
+//           isCorrect: true,
+//         },
+//       ],
+//     },
+//     {
+//       description: "nyt spørgsmål",
+//       options: [
+//         {
+//           text: "test",
+//           isCorrect: false,
+//         },
+//         {
+//           text: "test2",
+//           isCorrect: true,
+//         },
+//       ],
+//     },
+//   ],
+// };
+
+// //Add test quiz to store. Only temporary for mock data.
+// QuizStore.addQuiz(testQuiz1);
+// QuizStore.addQuiz(testQuiz2);
+// QuizStore.addQuiz(testQuiz3);


### PR DESCRIPTION
This branch fixes the issue where a lot of duplicate questions where fetched when fetching a quiz (because of the EAGER fetching). This is done by changing the backend entities to be fetched with Fetchtype.LAZY rather than Fetchtype.Eager.
LAZY is the the best practice, and eager was formerly only used, because I could'nt get it to work with lazy.

As a consequence of switching to LAZY fetching, some of the DAO methods need to convert the entities to DTOs inside the sessions. But this is not a problem.

Some things I also implemented/fixed in this branch:

- The "createdBy" user is now also fetched when fetching a single quiz or all quizzes.
- The models in the frontend is modified to to reflect changes to the dtos. It's tested and working.
- I added a util class, DTOUtil, for converting dtos, rather than always instantiating new objectMappers.

There are a lot of changes to files, but some of them are just caused by my linter/autoformatting..
