### PR TITLE
Fe#57 user signup page

### DIFF
--- a/web/src/components/login/LoginCard.tsx
+++ b/web/src/components/login/LoginCard.tsx
@@ -19,7 +19,7 @@ export const LoginCard: FC = () => {
             color="currentColor"
             variant="outline"
           >
-            Login with Google
+            Google
           </Button>
         </SimpleGrid>
       </Box>

--- a/web/src/components/login/LoginComponent.tsx
+++ b/web/src/components/login/LoginComponent.tsx
@@ -1,9 +1,12 @@
 import { Box, Heading, Text } from "@chakra-ui/layout";
-import { Link } from "react-router-dom";
 import { FC } from "react";
 import { LoginCard } from "./LoginCard";
 
-export const LoginComponent: FC = () => {
+interface LoginComponentProps {
+  showLogin: (showLogin: boolean) => void;
+}
+
+export const LoginComponent: FC<LoginComponentProps> = ({ showLogin }) => {
   return (
     <>
       <Box>
@@ -19,7 +22,14 @@ export const LoginComponent: FC = () => {
           fontWeight="medium"
         >
           <Text as="span">Don&apos;t have an account? </Text>
-          <Link to={"/signup"}>Sign up!</Link>
+          <Text
+            as="span"
+            cursor="pointer"
+            textDecoration="underline"
+            onClick={() => showLogin(false)}
+          >
+            Sign up!
+          </Text>
         </Text>
       </Box>
       <LoginCard />

--- a/web/src/components/login/LoginForm.tsx
+++ b/web/src/components/login/LoginForm.tsx
@@ -5,24 +5,22 @@ import {
   FormLabel,
 } from "@chakra-ui/form-control";
 import { Input, InputGroup, InputRightElement } from "@chakra-ui/input";
-import { Box, Flex, Stack } from "@chakra-ui/layout";
+import { Flex, Stack } from "@chakra-ui/layout";
 import { FC, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useColorModeValue as mode } from "@chakra-ui/react";
 import { HiEye, HiEyeOff } from "react-icons/hi";
-import {tokenStore} from "../stores/TokenStore";
+import { tokenStore } from "../stores/TokenStore";
 
 const LoginForm: FC = () => {
   const {
     register,
     handleSubmit,
-    watch,
     formState: { errors },
   } = useForm();
 
   const onSubmit = (data: any) => {
     const { email, password } = data;
-    tokenStore.login(email, password)
+    tokenStore.login(email, password);
     console.log(email, password);
   };
 
@@ -50,14 +48,14 @@ const LoginForm: FC = () => {
         <FormControl isInvalid={errors.password}>
           <Flex justify="space-between">
             <FormLabel htmlFor="password">Password</FormLabel>
-            <Box
+            {/* <Box
               as="a"
               color={mode("blue.600", "blue.200")}
               fontWeight="semibold"
               fontSize="sm"
             >
               Forgot Password?
-            </Box>
+            </Box> */}
           </Flex>
           <InputGroup>
             <InputRightElement>

--- a/web/src/components/signup/SignupCard.tsx
+++ b/web/src/components/signup/SignupCard.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@chakra-ui/button";
+import { Box, SimpleGrid } from "@chakra-ui/layout";
+import React, { FC } from "react";
+import { FaGoogle } from "react-icons/fa";
+import DividerWithText from "../login/DividerWithText";
+import { SignupForm } from "./SignupForm";
+
+export const SignupCard: FC = () => {
+  return (
+    <>
+      <Box p="6" rounded="md" mt="6" maxW="md" mx="auto">
+        <SignupForm />
+        <DividerWithText>or continue with</DividerWithText>
+        <SimpleGrid mt="6" columns={1} spacing="3">
+          <Button
+            rightIcon={<FaGoogle />}
+            color="currentColor"
+            variant="outline"
+          >
+            Google
+          </Button>
+        </SimpleGrid>
+      </Box>
+    </>
+  );
+};

--- a/web/src/components/signup/SignupComponent.tsx
+++ b/web/src/components/signup/SignupComponent.tsx
@@ -1,0 +1,38 @@
+import { Box, Heading, Text } from "@chakra-ui/layout";
+import React, { FC } from "react";
+import { SignupCard } from "./SignupCard";
+
+interface SignupComponentProps {
+  showLogin: (showLogin: boolean) => void;
+}
+
+export const SignupComponent: FC<SignupComponentProps> = ({ showLogin }) => {
+  return (
+    <>
+      <Box>
+        <Heading textAlign="center" size="xl" fontWeight="extrabold">
+          Create your account
+        </Heading>
+        <Text
+          mt="4"
+          mb="8"
+          align="center"
+          mx="auto"
+          maxW="md"
+          fontWeight="medium"
+        >
+          <Text as="span">Already have an account? </Text>
+          <Text
+            as="span"
+            cursor="pointer"
+            textDecoration="underline"
+            onClick={() => showLogin(true)}
+          >
+            Sign in here!
+          </Text>
+        </Text>
+      </Box>
+      <SignupCard />
+    </>
+  );
+};

--- a/web/src/components/signup/SignupForm.tsx
+++ b/web/src/components/signup/SignupForm.tsx
@@ -1,0 +1,115 @@
+import { Button, IconButton } from "@chakra-ui/button";
+import {
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+} from "@chakra-ui/form-control";
+import { Input, InputGroup, InputRightElement } from "@chakra-ui/input";
+import { Flex, Stack } from "@chakra-ui/layout";
+import React, { FC, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { HiEye, HiEyeOff } from "react-icons/hi";
+
+export const SignupForm: FC = () => {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data: any) => {
+    const { email, password, confirmedPassword } = data;
+    console.log(email, password, confirmedPassword);
+    //TODO call login endpoint
+  };
+
+  const [revealPassword, setRevealPassword] = useState(false);
+  const password = useRef({});
+  password.current = watch("password", "");
+
+  const onClickReveal = () => {
+    setRevealPassword((revealPassword) => !revealPassword);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack spacing="6">
+        <FormControl isInvalid={errors.email}>
+          <FormLabel htmlFor="email">Email address</FormLabel>
+          <Input
+            id="email"
+            type="email"
+            autoComplete="email"
+            {...register("email", { required: true })}
+          />
+          <FormErrorMessage>
+            {errors.email && errors.email.message}
+          </FormErrorMessage>
+        </FormControl>
+        <FormControl isInvalid={errors.password}>
+          <Flex justify="space-between">
+            <FormLabel htmlFor="password">Password</FormLabel>
+          </Flex>
+          <InputGroup>
+            <InputRightElement>
+              <IconButton
+                bg="transparent !important"
+                variant="ghost"
+                aria-label={
+                  revealPassword ? "Mask password" : "Reveal password"
+                }
+                icon={revealPassword ? <HiEyeOff /> : <HiEye />}
+                onClick={onClickReveal}
+              />
+            </InputRightElement>
+            <Input
+              id="password"
+              type={revealPassword ? "text" : "password"}
+              autoComplete="current-password"
+              {...register("password", {
+                required: true,
+              })}
+            />
+          </InputGroup>
+          <FormErrorMessage>
+            {errors.password && errors.password.message}
+          </FormErrorMessage>
+        </FormControl>
+        <FormControl isInvalid={errors.confirmedPassword}>
+          <Flex justify="space-between">
+            <FormLabel htmlFor="password">Confirm password</FormLabel>
+          </Flex>
+          <InputGroup>
+            <InputRightElement>
+              <IconButton
+                bg="transparent !important"
+                variant="ghost"
+                aria-label={
+                  revealPassword ? "Mask password" : "Reveal password"
+                }
+                icon={revealPassword ? <HiEyeOff /> : <HiEye />}
+                onClick={onClickReveal}
+              />
+            </InputRightElement>
+            <Input
+              id="confirmed-password"
+              type={revealPassword ? "text" : "password"}
+              autoComplete="current-password"
+              {...register("confirmedPassword", {
+                validate: (value) =>
+                  value === password.current || "The passwords do not match",
+              })}
+            />
+          </InputGroup>
+          <FormErrorMessage>
+            {errors.confirmedPassword && errors.confirmedPassword.message}
+          </FormErrorMessage>
+        </FormControl>
+        <Button type="submit" colorScheme="blue" size="lg" fontSize="md">
+          Sign up
+        </Button>
+      </Stack>
+    </form>
+  );
+};

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,11 +1,18 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import BasicLayout from "../components/layouts/basicLayout";
 import { LoginComponent } from "../components/login/LoginComponent";
+import { SignupComponent } from "../components/signup/SignupComponent";
 
 const LoginPage: FC = () => {
+  const [showLogin, setShowLogin] = useState<boolean>(true);
+
   return (
     <BasicLayout>
-      <LoginComponent></LoginComponent>
+      {showLogin ? (
+        <LoginComponent showLogin={(showLogin) => setShowLogin(showLogin)} />
+      ) : (
+        <SignupComponent showLogin={(showLogin) => setShowLogin(showLogin)} />
+      )}
     </BasicLayout>
   );
 };


### PR DESCRIPTION
The login page now has a local state that controls whether the signup component or login component is rendered. 

In the signup component, email is required and input type is email so standard html validation is done on the input. Password fields must also be a match but no further validation is applied to passwords. 

(This functions the same in the login component btw) 

Also made minor text changes in the login components. 

![image](https://user-images.githubusercontent.com/37805682/143003080-4da29546-dc5e-43bd-bc4d-6ac214a85d55.png)
